### PR TITLE
fix(sidebar): use tertiary text color for review_requested chip

### DIFF
--- a/src/components/sidebar/PrStatsRow.tsx
+++ b/src/components/sidebar/PrStatsRow.tsx
@@ -103,7 +103,7 @@ export function PrStatsRow({ prSummary }: { prSummary: PrSummary }) {
         </span>
       )}
       {reviewDecision === "review_requested" && (
-        <span className="flex items-center gap-1 text-xs text-status-busy">
+        <span className="flex items-center gap-1 text-xs text-text-tertiary">
           <UserPlus size={12} />
           {prSummary.requestedReviewers && prSummary.requestedReviewers.length > 0
             ? prSummary.requestedReviewers.length === 1


### PR DESCRIPTION
**What changed**
- Swap `text-status-busy` → `text-text-tertiary` on the `review_requested` chip in `PrStatsRow`

**Why**
- `text-status-busy` is the warm amber used for the "agent is running" status dot — sharing the token with a PR-state chip created semantic collision when both appeared on the same card
- `review_requested` and `review_required` are semantically the same family ("PR waiting on a human") and should look consistent; both now use `text-text-tertiary`

**Notes for reviewers**
- One-line change in `src/components/sidebar/PrStatsRow.tsx:106`
- Reserves `status-busy` exclusively for agent-running state going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)